### PR TITLE
Filter hidden categories and closed accounts from configuration selector

### DIFF
--- a/custom_components/ynab_custom/config_flow.py
+++ b/custom_components/ynab_custom/config_flow.py
@@ -113,11 +113,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             accounts_response = await self.api.get_accounts(self.budget_id)
             categories_response = await self.api.get_categories(self.budget_id)
 
-            self.accounts = {a["id"]: a["name"] for a in accounts_response.get("accounts", [])}
+            self.accounts = {
+                a["id"]: a["name"] 
+                for a in accounts_response.get("accounts", [])
+                if not a.get("closed", False)
+            }
             self.categories = {
                 c["id"]: c["name"]
                 for group in categories_response.get("category_groups", [])
                 for c in group.get("categories", [])
+                if not c.get("hidden", False)
             }
 
             _LOGGER.debug("Fetched %d accounts and %d categories", len(self.accounts), len(self.categories))


### PR DESCRIPTION
Hey there! Thanks for a great integration. 

I noticed when setting this up that the accounts and category selection had a ton of hidden categories and closed accounts. I believe this should help. Note - I do not have a local dev instance up, so I have not been able to test this code. In addition, I wonder if having this filter toggled by a checkbox during the config step may make more sense. Either way, sending this up as a draft to start the conversation.

Details:
- Updated config_flow.py to exclude closed accounts (closed=true) from account selection
- Updated config_flow.py to exclude hidden categories (hidden=true) from category selection
- Improves user experience by only showing active/relevant accounts and categories
- Leverages YNAB API properties: account.closed and category.hidden boolean flags
- Maintains existing 'Select All' functionality for filtered lists

Disclaimer:
- This was generate with https://ampcode.com/, but looks reasonable to me.